### PR TITLE
Remove [excludefromcodecoverage] and add tests

### DIFF
--- a/src/MockClassifier.Api/Dockerfile
+++ b/src/MockClassifier.Api/Dockerfile
@@ -12,4 +12,4 @@ RUN dotnet publish -c Release -o out
 FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app
 COPY --from=build-env /app/out .
-ENTRYPOINT ["dotnet", "DotNet.Docker.dll"]
+ENTRYPOINT ["dotnet", "MockClassifier.Api.dll"]

--- a/src/MockClassifier.Api/Services/Dmr/DmrHostedService.cs
+++ b/src/MockClassifier.Api/Services/Dmr/DmrHostedService.cs
@@ -1,11 +1,8 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace MockClassifier.Api.Services.Dmr
+﻿namespace MockClassifier.Api.Services.Dmr
 {
     /// <summary>
     /// A background hosted service that periodically triggers the DMR request processor
     /// </summary>
-    [ExcludeFromCodeCoverage] // Temporarily excluded from code coverage in order to get the CI pipeline merged. This attribute will be removed later.
     public sealed class DmrHostedService : IHostedService, IDisposable
     {
         private readonly IDmrService dmrService;

--- a/src/MockClassifier.Api/Services/Dmr/DmrServiceSettings.cs
+++ b/src/MockClassifier.Api/Services/Dmr/DmrServiceSettings.cs
@@ -1,8 +1,11 @@
-﻿namespace MockClassifier.Api.Services.Dmr
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace MockClassifier.Api.Services.Dmr
 {
     /// <summary>
     /// A settings object for <see cref="DmrService"/>
     /// </summary>
+    [ExcludeFromCodeCoverage] // No logic so not appropriate for code coverage
     public class DmrServiceSettings
     {
         private const string DefaultHttpClientName = "DmrApi";

--- a/src/MockClassifier.Api/Services/Dmr/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MockClassifier.Api/Services/Dmr/Extensions/ServiceCollectionExtensions.cs
@@ -1,12 +1,10 @@
 ﻿using Microsoft.Extensions.DependencyInjection.Extensions;
-using System.Diagnostics.CodeAnalysis;
 
 namespace MockClassifier.Api.Services.Dmr.Extensions
 {
     /// <summary>
     /// Extension class to help add all services related to the DMR
     /// </summary>
-    [ExcludeFromCodeCoverage] // Temporarily excluded from code coverage in order to get the CI pipeline merged. This attribute will be removed later.
     public static class ServiceCollectionExtensions
     {
         /// <summary>

--- a/src/MockClassifier.UnitTests/Services/Dmr/DmrHostedServiceTests.cs
+++ b/src/MockClassifier.UnitTests/Services/Dmr/DmrHostedServiceTests.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Extensions.Logging;
+using MockClassifier.Api.Services.Dmr;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MockClassifier.UnitTests.Services.Dmr
+{
+    public sealed class DmrHostedServiceTests : IDisposable
+    {
+        private readonly DmrHostedService sut;
+
+        public DmrHostedServiceTests()
+        {
+            DmrServiceSettings DefaultServiceConfig = new()
+            {
+                DmrApiUri = new Uri("https://dmr.fakeurl.com")
+            };
+            Mock<ILogger<DmrHostedService>> logger = new();
+            Mock<IDmrService> dmrService = new();
+            sut = new DmrHostedService(dmrService.Object, DefaultServiceConfig, logger.Object);
+        }
+
+        [Fact]
+        public async Task StartAsyncReturnsCompletedTask()
+        {
+            Task result = sut.StartAsync(default);
+            await result.ConfigureAwait(false);
+            Assert.Equal(TaskStatus.RanToCompletion, result.Status);
+        }
+
+        [Fact]
+        public async Task StopAsyncReturnsCompletedTask()
+        {
+            Task result = sut.StopAsync(default);
+            await result.ConfigureAwait(false);
+            Assert.Equal(TaskStatus.RanToCompletion, result.Status);
+        }
+
+        public void Dispose()
+        {
+            sut.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/MockClassifier.UnitTests/Services/Dmr/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MockClassifier.UnitTests/Services/Dmr/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MockClassifier.Api.Services.Dmr;
+using MockClassifier.Api.Services.Dmr.Extensions;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace MockClassifier.UnitTests.Services.Dmr.Extensions
+{
+    public sealed class ServiceCollectionExtensionsTests
+    {
+        [Fact]
+        public void AddDmrServiceAddsServices()
+        {
+            //Arrange
+            DmrServiceSettings DefaultServiceConfig = new()
+            {
+                DmrApiUri = new Uri("https://dmr.fakeurl.com"),
+                ClientName = "Foo",
+            };
+            var collection = new ServiceCollection();
+
+            // Act
+            collection.AddDmrService(DefaultServiceConfig);
+            var dmrService = collection.FirstOrDefault(e => e.ServiceType == typeof(IDmrService));
+            var dmrServiceSettings = collection.FirstOrDefault(e => e.ServiceType == typeof(DmrServiceSettings));
+            var dmrHostedService = collection.FirstOrDefault(e => e.ServiceType == typeof(IHostedService));
+
+            // Assert
+            Assert.Equal(ServiceLifetime.Singleton, dmrService.Lifetime);
+            Assert.Equal(ServiceLifetime.Singleton, dmrServiceSettings.Lifetime);
+            Assert.Equal(ServiceLifetime.Singleton, dmrHostedService.Lifetime);
+        }
+    }
+}


### PR DESCRIPTION
This PR removes some of the `excludefromcodecoverage` attributes that were added to pass the CI pipeline and adds appropriate tests to pass the code coverage targets.