### PR TITLE
Adding in CentOps integrated library and configuration

### DIFF
--- a/src/MockClassifier.Api/Controllers/MessagesController.cs
+++ b/src/MockClassifier.Api/Controllers/MessagesController.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Buerokratt.Common.AsyncProcessor;
+using Buerokratt.Common.Dmr;
+using Buerokratt.Common.Encoder;
+using Buerokratt.Common.Models;
+using Microsoft.AspNetCore.Mvc;
 using MockClassifier.Api.Interfaces;
-using RequestProcessor.AsyncProcessor;
-using RequestProcessor.Dmr;
-using RequestProcessor.Models;
-using RequestProcessor.Services.Encoder;
 using System.Text;
 using System.Text.Json;
 

--- a/src/MockClassifier.Api/MockClassifier.Api.csproj
+++ b/src/MockClassifier.Api/MockClassifier.Api.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Buerokratt.Common" Version="1.0.53-prerelease" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -22,7 +23,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
-    <PackageReference Include="RequestProcessor" Version="1.0.29" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
   </ItemGroup>
 

--- a/src/MockClassifier.Api/Program.cs
+++ b/src/MockClassifier.Api/Program.cs
@@ -21,8 +21,9 @@ namespace MockClassifier.Api
             var services = builder.Services;
 
             // Add services to the container.
-            var dmrSettings = configuration.GetSection("DmrServiceSettings").Get<DmrServiceSettings>();
-            var centOpsSettings = configuration.GetSection("DmrServiceSettings").Get<CentOpsServiceSettings>();
+            var settingsSectionName = "DmrServiceSettings";
+            var dmrSettings = configuration.GetSection(settingsSectionName).Get<DmrServiceSettings>();
+            var centOpsSettings = configuration.GetSection(settingsSectionName).Get<CentOpsServiceSettings>();
 
             services.AddDmrService(dmrSettings, centOpsSettings);
             services.TryAddSingleton<ITokenService, TokenService>();

--- a/src/MockClassifier.Api/Program.cs
+++ b/src/MockClassifier.Api/Program.cs
@@ -1,9 +1,10 @@
+using Buerokratt.Common.CentOps;
+using Buerokratt.Common.Dmr;
+using Buerokratt.Common.Dmr.Extensions;
+using Buerokratt.Common.Encoder;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using MockBot.Api.Services.Dmr.Extensions;
 using MockClassifier.Api.Interfaces;
 using MockClassifier.Api.Services;
-using RequestProcessor.Dmr;
-using RequestProcessor.Services.Encoder;
 using System.Diagnostics.CodeAnalysis;
 
 namespace MockClassifier.Api
@@ -21,7 +22,9 @@ namespace MockClassifier.Api
 
             // Add services to the container.
             var dmrSettings = configuration.GetSection("DmrServiceSettings").Get<DmrServiceSettings>();
-            services.AddDmrService(dmrSettings);
+            var centOpsSettings = configuration.GetSection("DmrServiceSettings").Get<CentOpsServiceSettings>();
+
+            services.AddDmrService(dmrSettings, centOpsSettings);
             services.TryAddSingleton<ITokenService, TokenService>();
             services.TryAddSingleton<INaturalLanguageService, NaturalLanguageService>();
             services.TryAddSingleton<IEncodingService, EncodingService>();

--- a/src/MockClassifier.Api/appsettings.json
+++ b/src/MockClassifier.Api/appsettings.json
@@ -7,9 +7,7 @@
   },
   "AllowedHosts": "*",
   "DmrServiceSettings": {
-    "DmrServiceSettings": {
-      "CentOpsUri": "http://127.0.0.1:8080",
-      "CentOpsApiKey": "<generate a key>"
-    }
+    "CentOpsUri": "http://127.0.0.1:8080",
+    "CentOpsApiKey": "<generate a key>"
   }
 }

--- a/src/MockClassifier.Api/appsettings.json
+++ b/src/MockClassifier.Api/appsettings.json
@@ -7,7 +7,9 @@
   },
   "AllowedHosts": "*",
   "DmrServiceSettings": {
-    "DmrApiUri": "https://tablelogapi.azurewebsites.net/app/fromclassifier",
-    "DmrRequestProcessIntervalMs": 5000
+    "DmrServiceSettings": {
+      "CentOpsUri": "http://127.0.0.1:8080",
+      "CentOpsApiKey": "<generate a key>"
+    }
   }
 }

--- a/src/MockClassifier.IntegrationTests/MockClassifier.IntegrationTests.csproj
+++ b/src/MockClassifier.IntegrationTests/MockClassifier.IntegrationTests.csproj
@@ -12,12 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Buerokratt.Common" Version="1.0.53-prerelease" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="RequestProcessor" Version="1.0.29" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MockClassifier.UnitTests/Extensions/MockHttpMessageHandlerExtensions.cs
+++ b/src/MockClassifier.UnitTests/Extensions/MockHttpMessageHandlerExtensions.cs
@@ -1,5 +1,5 @@
-﻿using RequestProcessor.Dmr;
-using RequestProcessor.Services.Encoder;
+﻿using Buerokratt.Common.Dmr;
+using Buerokratt.Common.Encoder;
 using RichardSzalay.MockHttp;
 using System.Net;
 using System.Text.Json;

--- a/src/MockClassifier.UnitTests/MessagesControllerTests.cs
+++ b/src/MockClassifier.UnitTests/MessagesControllerTests.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Buerokratt.Common.AsyncProcessor;
+using Buerokratt.Common.Dmr;
+using Buerokratt.Common.Encoder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using MockClassifier.Api.Controllers;
 using MockClassifier.Api.Services;
 using Moq;
-using RequestProcessor.AsyncProcessor;
-using RequestProcessor.Dmr;
-using RequestProcessor.Services.Encoder;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/MockClassifier.UnitTests/MockClassifier.UnitTests.csproj
+++ b/src/MockClassifier.UnitTests/MockClassifier.UnitTests.csproj
@@ -12,13 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Buerokratt.Common" Version="1.0.53-prerelease" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.0" />
-    <PackageReference Include="RequestProcessor" Version="1.0.29" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
- Mock Classifier now expects to talk to CentOps to get Dmr location.
- This means configuration to allow this to happen - e.g. a Participant for Mock Classifier needs to be created.
- This will affect integration tests.