### PR TITLE
72 mclassifier return none ministry if a ministry cannot be identified

### DIFF
--- a/src/MockClassifier.Api/Controllers/MessagesController.cs
+++ b/src/MockClassifier.Api/Controllers/MessagesController.cs
@@ -4,6 +4,7 @@ using Buerokratt.Common.Encoder;
 using Buerokratt.Common.Models;
 using Microsoft.AspNetCore.Mvc;
 using MockClassifier.Api.Interfaces;
+using MockClassifier.Api.Models;
 using System.Text;
 using System.Text.Json;
 
@@ -54,6 +55,12 @@ namespace MockClassifier.Api.Controllers
             // Classify
             List<string> classifications = _naturalLanguageService.Classify(payload.Message).ToList();
             classifications.AddRange(_tokenService.Classify(payload.Message).ToList());
+
+            // Add none classification if no classifications have been found
+            if (classifications.Count == 0)
+            {
+                classifications.Add(Ministry.none.ToString());
+            }
 
             // Send Dmr call back(s)
             foreach (var classification in classifications)

--- a/src/MockClassifier.Api/Models/MinistryEnum.cs
+++ b/src/MockClassifier.Api/Models/MinistryEnum.cs
@@ -12,6 +12,7 @@
         finance,
         social,
         interior,
-        foreign
+        foreign,
+        none
     }
 }

--- a/src/MockClassifier.UnitTests/MessagesControllerTests.cs
+++ b/src/MockClassifier.UnitTests/MessagesControllerTests.cs
@@ -44,6 +44,11 @@ namespace MockClassifier.UnitTests
 
             // Assert
             _ = Assert.IsType<AcceptedResult>(result);
+            dmrService
+                .Verify(
+                    x => x.Enqueue(
+                        It.Is<DmrRequest>(d => d.Payload.Classification == "none")),
+                    Times.Once());
             dmrService.VerifyNoOtherCalls();
         }
 

--- a/src/MockClassifier.UnitTests/Services/NaturalLanguageServiceTest.cs
+++ b/src/MockClassifier.UnitTests/Services/NaturalLanguageServiceTest.cs
@@ -20,8 +20,8 @@ namespace MockClassifier.UnitTests.Services
         [InlineData("I have a question about the Estonian pension system", new string[] { "economic" })]
         [InlineData("How do I file my annual tax information", new string[] { "economic" })]
         [InlineData("i want to register my child at school", new string[] { "education" })]
-        [InlineData("", new string[] { "none" })]
-        [InlineData("not mapped", new string[] { "none" })]
+        [InlineData("", new string[] { })]
+        [InlineData("not mapped", new string[] { })]
         public void TestClassify(string messageBody, string[] expectedMinistries)
         {
             var result = naturalLanguageService.Classify(messageBody);

--- a/src/MockClassifier.UnitTests/Services/NaturalLanguageServiceTest.cs
+++ b/src/MockClassifier.UnitTests/Services/NaturalLanguageServiceTest.cs
@@ -20,8 +20,8 @@ namespace MockClassifier.UnitTests.Services
         [InlineData("I have a question about the Estonian pension system", new string[] { "economic" })]
         [InlineData("How do I file my annual tax information", new string[] { "economic" })]
         [InlineData("i want to register my child at school", new string[] { "education" })]
-        [InlineData("", new string[] { })]
-        [InlineData("not mapped", new string[] { })]
+        [InlineData("", new string[] { "none" })]
+        [InlineData("not mapped", new string[] { "none" })]
         public void TestClassify(string messageBody, string[] expectedMinistries)
         {
             var result = naturalLanguageService.Classify(messageBody);


### PR DESCRIPTION
This PR changes the logic of classifier to return a "none" classification to DMR if no other classification can be found.